### PR TITLE
Code review fixes (header + README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,53 @@ Shell function to search for a host in ~/.ssh/config and connect to it
 
 ## Usage
 
-- sshs: Shows  the list of hosts in the config file
-- sshs [param]: Searches the config file for the corresponding hosts. (ignore case)
+- `sshs`: Shows the list of hosts in the config file
+- `sshs [param]`: Searches the config file for the corresponding hosts (case insensitive)
+- `sshs -r [param]`: Searches using regex pattern (regex metacharacters are interpreted)
 
-## Config variable
+## Config variables
 
-- SSHS_MENU : string containing the list of characters available for selection in the menu,
-              default value: '0123456789'. The length of the string determines the maximum
+- `SSHS_MENU`: String containing the list of characters available for selection in the menu,
+              default value: `0123456789`. The length of the string determines the maximum
               size of the menu.
-- SSHS_CONFIG : ssh configuration file used, default value: '~/.ssh/config'
+- `SSHS_CONFIG`: SSH configuration file used, default value: `~/.ssh/config`
+- `SSHS_REGEX`: When set to any value, enables regex mode (metacharacters like `.`, `*`, `[` are interpreted).
+              Can also be enabled per-call with the `-r` flag.
+
+## Regex mode
+
+By default, regex metacharacters in search terms are escaped so they are treated as literal text.
+This prevents accidental regex injection (e.g. `sshs [a-z]` searches for the literal string `[a-z]`).
+
+To use regex patterns intentionally, either:
+```sh
+sshs -r 'dev_.*master'
+```
+or:
+```sh
+SSHS_REGEX=1 sshs 'dev_.*master'
+```
 
 ## Result
 
-- if 0 host found : Not found message
-- if 1 host found : Immediate connection
-- if <= (size SSHS_MENU) hosts found : Selection menu and connection to the chosen host
-- if > (size SSHS_MENU) results : Show host list and exit
+- if 0 host found: Not found message
+- if 1 host found: Immediate connection
+- if <= (size SSHS_MENU) hosts found: Selection menu and connection to the chosen host
+- if > (size SSHS_MENU) results: Show host list and exit
 
 ## Advice
 
-- Source the file sshs.sh in .bashrc
-- In the ~/.ssh/config file, add a comment '#' with a description on the line above the 'Host'
+- Source the file `sshs.sh` in `.bashrc`
+- In the `~/.ssh/config` file, add a comment `#` with a description on the line above the `Host`
   element. This line is used for the search and the list of results displayed by the function.
-- If the comment line contains sshs-off, the host is ignored
+- If the comment line contains `sshs-off`, the host is ignored
+
+## Tests
+
+Run the test suite:
+```sh
+./test.sh
+```
 
 ## Example
 
@@ -68,26 +92,36 @@ $ sshs
 2) dev_k3s_worker1  # dev, k3s, kubernetes, worker
 3) dev_k3s_worker2  # dev, k3s, kubernetes, worker
 4) dev_k3s_worker3  # dev, k3s, kubernetes, worker
-Choose an option:
+Choose an option (other key to cancel):
 ```
 
-### search k3s worker : three results, choice
+### search k3s worker: three results, choice
 
 ```sh
 $ sshs k3s worker
 0) dev_k3s_worker1  # dev, k3s, kubernetes, worker
 1) dev_k3s_worker2  # dev, k3s, kubernetes, worker
 2) dev_k3s_worker3  # dev, k3s, kubernetes, worker
-Choose an option:
+Choose an option (other key to cancel):
 ```
 
-### search dev master : one result, autochoice
+### search dev master: one result, autochoice
 
 ```txt
 $ sshs dev master
 >>> Connect to dev_k3s_master <<<
 dev_k3s_master:~$ exit
->>> Disconnected from dev_k3s_master <<<
+>>> Disconnected from dev_k3s_master (exit 0) <<<
+```
+
+### search with regex (-r flag)
+
+```sh
+$ sshs -r 'dev_.*worker'
+0) dev_k3s_worker1  # dev, k3s, kubernetes, worker
+1) dev_k3s_worker2  # dev, k3s, kubernetes, worker
+2) dev_k3s_worker3  # dev, k3s, kubernetes, worker
+Choose an option (other key to cancel):
 ```
 
 ### Set menu
@@ -99,7 +133,7 @@ b) dev_k3s_master   # dev, k3s, kubernetes, master
 c) dev_k3s_worker1  # dev, k3s, kubernetes, worker
 d) dev_k3s_worker2  # dev, k3s, kubernetes, worker
 e) dev_k3s_worker3  # dev, k3s, kubernetes, worker
-Choose an option:
+Choose an option (other key to cancel):
 ```
 
 ### Set ssh config file
@@ -112,5 +146,5 @@ $ sshs
 2) tst_k3s_worker1  # tst, k3s, kubernetes, worker
 3) tst_k3s_worker2  # tst, k3s, kubernetes, worker
 4) tst_k3s_worker3  # tst, k3s, kubernetes, worker
-Choose an option:
+Choose an option (other key to cancel):
 ```

--- a/sshs.sh
+++ b/sshs.sh
@@ -23,18 +23,31 @@
 #     element. This line is used for the search and the list of results displayed by the function.
 #   - If the comment line contains sshs-off, the host is ignored
 # --------------------------------------------------------------------------------------------------
-sshs () {
-    local tblCom=() tblHost=() i=0 line='' hSize=0 fields=()
-    local search="$*"; search=${search,,}; search="${search// /.*}"; search=${search:-'.*'}
-    local menu="${SSHS_MENU:="0123456789"}"
-    local config="${SSHS_CONFIG:="$HOME/.ssh/config"}"
+sshs_connect() {
+    local host="$1" config="$2"
+    echo -e "\e[32m>>> Connect to $host <<<\e[0m"
+    ssh -F "${config}" "$host"
+    local ret=$?
+    if (( ret == 255 )); then
+        echo -e "\e[31m>>> Connection to $host failed <<<\e[0m"
+    else
+        echo -e "\e[32m>>> Disconnected from $host (exit $ret) <<<\e[0m"
+    fi
+    return $ret
+}
+sshs_strindex() { local x="${1%%"$2"*}"; [[ "$x" = "$1" ]] && echo -1 || echo "${#x}"; }
 
-    sshs_connect() {
-        echo -e "\e[32m>>> Connect to $1 <<<\e[0m"
-        ssh -F "${config}" "$1"
-        echo -e "\e[32m>>> Disconnected from $1 <<<\e[0m"
-    }
-    sshs_strindex() { local x="${1%%"$2"*}"; [[ "$x" = "$1" ]] && echo -1 || echo "${#x}"; }
+sshs () {
+    local tblCom=() tblHost=() i=0 line='' hSize=0 fields=() padding=''
+    local regex=0
+    [[ "$1" == "-r" ]] && { regex=1; shift; }
+    local search="$*"; search=${search,,}
+    if (( ! regex )) && [[ -z "${SSHS_REGEX:-}" ]]; then
+        search=$(sed 's/[].[\*+?^${}()|\\]/\\&/g' <<< "$search")
+    fi
+    search="${search// /.*}"; search=${search:-'.*'}
+    local menu="${SSHS_MENU:-"0123456789"}"
+    local config="${SSHS_CONFIG:-"$HOME/.ssh/config"}"
 
     while IFS= read -r line; do
         if [[ "${line,,}" =~ ^host[[:space:]] ]]; then
@@ -50,22 +63,23 @@ sshs () {
         else pline=''; fi
     done < "${config}"
 
-    line=''; for ((i=0;i<hSize;i++)); do line="${line} "; done
+    padding=''; for ((i=0;i<hSize;i++)); do padding="${padding} "; done
     for ((i = 0 ; i < ${#tblHost[@]} ; i++)); do
-        tblHost[i]="${tblHost[i]:0:$hSize}${line:0:$((hSize-${#tblHost[i]}))}"
+        tblHost[i]="${tblHost[i]:0:$hSize}${padding:0:$((hSize-${#tblHost[i]}))}"
     done
 
     if (( ${#tblHost[@]} == 0 )); then
-        echo -e "\e[31m${FUNCNAME[0]}: '$search' not found in ~/.ssh/config\e[0m"
+        echo -e "\e[31m${FUNCNAME[0]}: '$search' not found in ${config}\e[0m"
     elif (( ${#tblHost[@]} == 1 )); then
-        sshs_connect "${tblHost[0]//[[:space:]]/}"
+        sshs_connect "${tblHost[0]//[[:space:]]/}" "$config"
     elif (( ${#tblHost[@]} <= ${#menu} )); then
         for ((i = 0 ; i < ${#tblHost[@]} ; i++)); do
             [[ "${tblCom[i]}" != "" ]] && echo -e "\e[32m${menu:$i:1}\e[0m) ${tblHost[i]}\e[31m ${tblCom[i]}\e[0m" \
                                        || echo -e "\e[32m${menu:$i:1}\e[0m) ${tblHost[i]}"
         done
-        echo -ne "Choose an option: "; read -rn1 i; echo
-        [[ "$i" != "" && "$menu" == *"$i"* ]] && sshs_connect "${tblHost[$(sshs_strindex "$menu" "$i")]//[[:space:]]/}"
+        echo -ne "Choose an option (other key to cancel): "; read -rn1 i; echo
+        # Only connect if key is in menu — sshs_strindex returns -1 otherwise, guarded here
+        [[ "$i" != "" && "$menu" == *"$i"* ]] && sshs_connect "${tblHost[$(sshs_strindex "$menu" "$i")]//[[:space:]]/}" "$config"
     else
         for ((i = 0 ; i < ${#tblHost[@]} ; i++)); do
             [[ "${tblCom[i]}" != "" ]] && echo -e "${tblHost[i]}\e[31m ${tblCom[i]}\e[0m" \

--- a/sshs.sh
+++ b/sshs.sh
@@ -6,11 +6,13 @@
 # Usage:
 #   - sshs: Shows  the list of hosts in the config file
 #   - sshs [param]: Searches the config file for the corresponding hosts. (ignore case)
+#   - sshs -r [param]: Searches using regex pattern (metacharacters interpreted)
 # Variable:
 #   - SSHS_MENU : string containing the list of characters available for selection in the menu,
 #                 default value: '0123456789'. The length of the string determines the maximum
 #                 size of the menu.
 #   - SSHS_CONFIG : ssh configuration file used, default value: '~/.ssh/config'
+#   - SSHS_REGEX : when set, enables regex mode (same as -r flag)
 # Result:
 #   - if 0 host found: Not found message
 #   - if 1 host found: Immediate connection

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Tests for sshs.sh
+# Run: cd /home/mdo/code/sshs && ./test.sh
+
+cd "$(dirname "$0")"
+source sshs.sh
+
+PASS=0 FAIL=0
+
+check() {
+    local desc="$1" expected="$2" cmd="$3"
+    local out
+    out=$(SSHS_CONFIG=ssh_config_test/config5 bash -c "source sshs.sh; $cmd" </dev/null 2>&1) || true
+    # Strip ANSI escape codes before matching
+    local clean; clean=$(echo "$out" | sed 's/\x1b\[[0-9;]*m//g')
+    if echo "$clean" | grep -qF "$expected"; then
+        echo "  ✓ $desc"
+        ((PASS++))
+    else
+        echo "  ✗ $desc"
+        echo "    expected: $expected"
+        echo "    got:      $out"
+        ((FAIL++))
+    fi
+}
+
+echo "=== sshs tests ==="
+echo ""
+
+check "Liste tous les hôtes"                  "dev_bastion"           'sshs'
+check "Recherche simple"                       "dev_k3s_master"        'sshs master'
+check "Recherche multi-mots"                   "k3s_worker1"           'sshs k3s worker'
+check "1 résultat → auto-connexion"             "Connect to dev_k3s_master" 'sshs k3s master'
+check "sshs-off ignoré (Host* absent)"         "dev_k3s_master"        'sshs k3s'
+check "Menu personnalisé (abcde)"              "a) dev_bastion"        'SSHS_MENU=abcde sshs'
+check "SSHS_MENU préservé après appel"         "OK"                    'SSHS_MENU="" sshs >/dev/null 2>&1; [[ "$SSHS_MENU" == "" ]] && echo OK'
+check "Config alternatif config30"             "pve.lab"               'SSHS_CONFIG=ssh_config_test/config30 sshs pve'
+check "Flag -r (regex)"                        "dev_k3s_master"        'sshs -r "dev_.*master"'
+check "Variable SSHS_REGEX"                    "dev_k3s_master"        'SSHS_REGEX=1 sshs "dev_.*master"'
+check "Safe mode: [a-z] → pas d'injection"     "not found"             'sshs "[a-z]"'
+check "Aucun résultat"                         "not found"             'sshs zzz_nonexistent_zzz'
+check "Trop de résultats → liste sans menu"    "dev_bastion"           'SSHS_MENU=ab sshs dev'
+check "Prompt 'other key to cancel' visible"   "other key to cancel"   'sshs'
+check "Échec connexion SSH → failed"           "failed"                'sshs dev_k3s_master'
+
+echo ""
+echo "=== $PASS PASS, $FAIL FAIL ==="
+exit $FAIL

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,17 @@
+# Code Review — sshs.sh
+
+## 🔴 Sévère
+
+- [x] **L29-30 : `:=` au lieu de `:-`** — `SSHS_MENU` et `SSHS_CONFIG` sont modifiées globalement si vides. Remplacer `:=` par `:-`.
+- [x] **L34 : Pas de check du code retour de `ssh`** — « Disconnected » affiché même si la connexion échoue. Vérifier `$?` après `ssh`.
+- [x] **L67-68 : Prompt menu ambigu** — Le comportement (touche hors menu = annulation) est volontaire, mais le prompt ne l'indique pas. Ajouter `(other key to cancel)` au message.
+
+## 🟡 Mineur
+
+- [x] **L32,37 : Fonctions imbriquées redéfinies à chaque appel** — Extraire `sshs_connect` et `sshs_strindex` hors de `sshs()`.
+- [x] **L42 : `$search` non échappé dans une regex** — Les métacaractères (`[`, `.`, `*`) sont interprétés. Échapper ou passer en matching shell (`==`).
+- [x] **L59 : Message d'erreur mentionne `~/.ssh/config` en dur** — Utiliser `$config` pour refléter `SSHS_CONFIG`.
+- [x] **L45 : `$i` non quoté dans `(( ))`** — `"$i"` plus robuste. → Faux problème : `(( ))` est un contexte arithmétique, pas de word splitting.
+- [x] **L53 : Variable `line` réutilisée pour le padding** — Renommer en `padding` pour lisibilité.
+- [x] **L68 : `tblHost[-1]` implicite** — `sshs_strindex` retourne `-1`, protégé uniquement par la garde au-dessus. Rendre explicite. → Commentaire ajouté.
+- [x] **Variables `tblCom`/`tblHost` cryptiques** — Renommer `comments`/`hostnames`. → Accepté, noms cohérents pour le contexte.


### PR DESCRIPTION
## Changes

- Fix `:= `→ `:-` to avoid global variable pollution on `SSHS_MENU` and `SSHS_CONFIG`
- Check SSH exit code (255 = connection failed, otherwise disconnected with exit code)
- Move `sshs_connect` / `sshs_strindex` to global scope (no longer redefined on each call)
- Escape regex metacharacters in safe mode (`.` `*` `[` etc. treated as literal text)
- Add `-r` flag and `SSHS_REGEX` variable for explicit regex mode
- Use `$config` in error message instead of hardcoded `~/.ssh/config`
- Rename `line` padding variable to `padding` for clarity
- Add comment documenting `tblHost[-1]` guard
- Add "other key to cancel" hint to menu prompt
- Add test suite (`test.sh` — 15 tests)
- Update README with new features and examples
- Update file header comment with `-r` flag and `SSHS_REGEX`

See `todo.md` for the full code review.